### PR TITLE
Fix a MIDIServer crash in `USBDeviceManager::DevicesAdded()`.

### DIFF
--- a/MIDISPORTFirmwareDownloader/USBUtils.cpp
+++ b/MIDISPORTFirmwareDownloader/USBUtils.cpp
@@ -190,6 +190,7 @@ void	USBDeviceManager::DevicesRemoved(io_iterator_t devIter)
 		printf("removed device 0x%X\n", (int)ioDeviceObj);
 #endif
 		DeviceRemoved(ioDeviceObj);
+		IOObjectRelease(ioDeviceObj);
 	}
 }
 
@@ -221,9 +222,6 @@ void	USBDeviceManager::DevicesAdded(io_iterator_t devIter)
             __Require(kr == kIOReturnSuccess, nextDevice);
             continue;
         }
-        // Don't need the device object after intermediate plug-in is created
-        kr = IOObjectRelease(ioDeviceObj);
-        __Require(kr == kIOReturnSuccess, nextDevice);
 
         // Now create the device interface
 		kr = (*ioPlugin)->QueryInterface(ioPlugin,


### PR DESCRIPTION
We were releasing an `io_service_t` returned by `IOIteratorNext()`, twice. The second time would often crash. (If it didn't, we were just lucky.)

The crash typically happened soon after the MIDIServer started, here:
```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x1b9af98c4 _kernelrpc_mach_port_deallocate_trap + 8
1   libsystem_kernel.dylib        	       0x1b9afacd0 mach_port_deallocate + 28
2   MIDISPORT                     	       0x10339ec64 USBDeviceManager::DevicesAdded(unsigned int) + 1112
3   MIDISPORT                     	       0x10339eda0 USBDeviceManager::ScanDevices() + 52
4   MIDISPORT                     	       0x10339dba4 0x103398000 + 23460
5   MIDISPORT                     	       0x10339d47c USBMIDIDriverBase::Start(unsigned int) + 48
6   CoreMIDI                      	       0x1d008268c MIDIDriverMgr::StartMIDI() + 220
7   CoreMIDI                      	       0x1d007b738 SetupManager::Install(MIDISetup*, bool) + 252
8   CoreMIDI                      	       0x1d006bd44 MIDIServerRun + 4480
9   MIDIServer                    	       0x102ffbed0 0x102ff8000 + 16080
10  dyld                          	       0x1032a50f4 start + 520
```

It looks like this code was added in d7f4805:
```
        // Don't need the device object after intermediate plug-in is created
        kr = IOObjectRelease(ioDeviceObj);
        __Require(kr == kIOReturnSuccess, nextDevice);
```

But there was already a release at the end of the loop:
```
		IOObjectRelease(ioDeviceObj);
```
Also, the comment seems to be wrong, because we do use `ioDeviceObj` afterwards. We shouldn't release it until we're totally done with it.

I checked the other code that calls `IOIteratorNext()`, and it looks like we have the opposite bug in `USBDeviceManager::DevicesRemoved()`: we're not releasing the object we get from the iterator. Fixed that too.